### PR TITLE
Update bpftool-build base image to s390x/debian:bullseye-slim

### DIFF
--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -9,7 +9,7 @@ RUN apk --update add curl
 RUN curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${QEMU_ARCHS}-static.tar.gz | tar zxvf - -C /usr/bin &&\
     chmod +x /usr/bin/qemu-s390x-static
 
-FROM s390x/debian:buster-slim as bpftool-build
+FROM s390x/debian:bullseye-slim as bpftool-build
 ARG KERNEL_REPO=git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 ARG KERNEL_REF=master
 
@@ -18,7 +18,7 @@ COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
 RUN apt-get update && \
 apt-get upgrade -y && \
 apt-get install -y --no-install-recommends \
-    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-8-dev \
+    gpg gpg-agent libelf-dev libmnl-dev libc-dev iptables libgcc-10-dev \
     bash-completion binutils binutils-dev make git curl \
     ca-certificates xz-utils gcc pkg-config bison flex build-essential && \
 apt-get purge --auto-remove && \


### PR DESCRIPTION
Buster standard security support has ended as of August 1st, causing bpftool build to fail.
Hence updating bpftool-build base image to bullseye-slim.