### PR TITLE
Rev bpftool to v7.5.0; get Makefile working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ifeq ($(ARCH),x86_64)
 endif
 
 ###############################################################################
-VERSION ?= v7.4.0
+VERSION ?= v7.5.0
 DEFAULTORG ?= calico
 DEFAULTIMAGE ?= $(DEFAULTORG)/bpftool:$(VERSION)
 ARCHIMAGE ?= $(DEFAULTIMAGE)-$(ARCH)

--- a/Makefile
+++ b/Makefile
@@ -1,105 +1,51 @@
 # Shortcut targets
-default: image
+default: all
 
 ## Build binary for current platform
-all: image-all
-###############################################################################
-# Both native and cross architecture builds are supported.
-# The target architecture is select by setting the ARCH variable.
-# When ARCH is undefined it is set to the detected host architecture.
-# When ARCH differs from the host architecture a crossbuild will be performed.
-ARCHES = amd64 arm64 ppc64le s390x
-
-# BUILDARCH is the host architecture
-# ARCH is the target architecture
-# we need to keep track of them separately
-BUILDARCH ?= $(shell uname -m)
-
-# canonicalized names for host architecture
-ifeq ($(BUILDARCH),aarch64)
-        BUILDARCH=arm64
-endif
-ifeq ($(BUILDARCH),x86_64)
-        BUILDARCH=amd64
-endif
-
-# unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
-ARCH ?= $(BUILDARCH)
-
-# canonicalized names for target architecture
-ifeq ($(ARCH),aarch64)
-        override ARCH=arm64
-endif
-ifeq ($(ARCH),x86_64)
-        override ARCH=amd64
-endif
+all: image
 
 ###############################################################################
+# Input parameters.
+###############################################################################
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
 VERSION ?= v7.5.0
-DEFAULTORG ?= calico
-DEFAULTIMAGE ?= $(DEFAULTORG)/bpftool:$(VERSION)
-ARCHIMAGE ?= $(DEFAULTIMAGE)-$(ARCH)
-BPFTOOLIMAGE ?= $(DEFAULTIMAGE)-$(BUILDARCH)
+IMAGE_ORG ?= calico
+IMAGE ?= $(IMAGE_ORG)/bpftool:$(VERSION)
 SOURCEREF ?= $(VERSION)
 SOURCEREPO ?= https://github.com/libbpf/bpftool.git
 
-MANIFEST_TOOL_VERSION := v0.7.0
-MANIFEST_TOOL_DIR := $(shell mktemp -d)
-export PATH := $(MANIFEST_TOOL_DIR):$(PATH)
-
-space :=
-space +=
-comma := ,
-prefix_linux = $(addprefix linux/,$(strip $(subst armv,arm/v,$1)))
-join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
-
-# Check if the docker daemon is running in experimental mode (to get the --squash flag)
-DOCKER_EXPERIMENTAL=$(shell docker version -f '{{ .Server.Experimental }}')
-DOCKER_BUILD_ARGS=
-ifeq ($(DOCKER_EXPERIMENTAL),true)
-        override DOCKER_BUILD_ARGS=--squash
-endif
-
 ###############################################################################
-# Building the image
+# Building the images
 ###############################################################################
-image: $(DEFAULTORG)/bpftool
-$(DEFAULTORG)/bpftool: register
-	# Make sure we re-pull the base image to pick up security fixes.
-	docker build $(DOCKER_BUILD_ARGS) --platform=linux/$(ARCH) --build-arg SOURCE_REF=$(SOURCEREF) --build-arg SOURCE_REPO=$(SOURCEREPO) --pull -t $(ARCHIMAGE) -f Dockerfile .
 
-image-all: $(addprefix sub-image-,$(ARCHES))
-sub-image-%:
-	$(MAKE) image ARCH=$*
+PLATFORM_ARG=--platform $(DOCKER_PLATFORMS)
 
-# Enable binfmt adding support for miscellaneous binary formats.
+image-single-platform:
+	$(MAKE) image PLATFORM_ARG=
+
+image: register
+	docker buildx build \
+	       $(PUSH_ARG) \
+		   $(PLATFORM_ARG) \
+	       --build-arg SOURCE_REF=$(SOURCEREF) \
+	       --build-arg SOURCE_REPO=$(SOURCEREPO) \
+	       --tag $(IMAGE) .
+
+push:
+	$(MAKE) image PUSH_ARG=--push 
+
+# Enable support for non-native binaries so that cross-platform builds can be
+# done. This is needed for the buildx build command.
+# See https://docs.docker.com/build/building/multi-platform/#install-qemu-manually
 .PHONY: register
 register:
-ifeq ($(ARCH),amd64)
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-endif
-
-push: image
-	docker push $(ARCHIMAGE)
-	# to handle default case, because quay.io does not support manifest yet
-ifeq ($(ARCH),amd64)
-	docker tag $(ARCHIMAGE) quay.io/$(DEFAULTIMAGE)
-	docker push quay.io/$(DEFAULTIMAGE)
-endif
-
-push-all: $(addprefix sub-push-,$(ARCHES))
-sub-push-%:
-	$(MAKE) push ARCH=$*
-
-push-manifest:
-	# Docker login to hub.docker.com required before running this target as we are using $(HOME)/.docker/config.json holds the docker login credentials
-	docker run -t --entrypoint /bin/sh -v $(HOME)/.docker/config.json:/root/.docker/config.json $(ARCHIMAGE) -c "/usr/bin/manifest-tool push from-args --platforms $(call join_platforms,$(ARCHES)) --template $(DEFAULTIMAGE)-ARCHVARIANT --target $(DEFAULTIMAGE)"
+	docker run --privileged --rm tonistiigi/binfmt --install all
 
 ###############################################################################
 # UTs
 ###############################################################################
 test:
-	docker run --rm $(BPFTOOLIMAGE) /bpftool version | grep -q "bpftool v"
+	docker run --rm $(IMAGE) /bpftool version | grep -q "bpftool v"
 	@echo "success"
 
 ###############################################################################
@@ -107,7 +53,7 @@ test:
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: image-all test
+ci: image test
 
 ###############################################################################
 # CD
@@ -118,8 +64,4 @@ cd:
 ifndef CONFIRM
 	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
 endif
-ifndef BRANCH_NAME
-	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
-endif
-	$(MAKE) push-all VERSION=${BRANCH_NAME}
-	$(MAKE) push-manifest VERSION=${BRANCH_NAME}
+	$(MAKE) push

--- a/README.md
+++ b/README.md
@@ -3,14 +3,26 @@
 Base image including a statically compiled bpftool for other calico projects to use.
 
 ## Building the image
-To build the image:
+To build the multi-arch image:
+
+Make sure you have configured docker for multi-arch builds: [enable the 
+containerd image store](https://docs.docker.com/engine/storage/containerd/).  Then:
 
 ```
 make image
 ```
 
-The above will build for whatever architecture you are running on. To force a different architecture:
-
+To build a single-arch image for your system:
 ```
-ARCH=<somearch> make image
+make image-single-platform
+```
+
+To build for specific platforms, use the `DOCKER_PLATFORMS` variable:
+```
+make image DOCKER_PLATFORMS=linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
+```
+
+To build/push the image:
+```
+make push
 ```


### PR DESCRIPTION
Hoping that revving version will fix this error, which we sometimes see in CI:
```
can't query bpf programs attached to /run/calico/cgroup: No such device or address
```
Upstream bug: https://github.com/libbpf/bpftool/issues/149

Found that the makefile didn't work for multi-arch builds (AFAICT!) so I reworked it to use the up-to-date instructions from docker: https://docs.docker.com/build/building/multi-platform/