### PR TITLE
Introduce build for `riscv64`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM --platform=amd64 calico/qemu-user-static:latest as qemu
 
-FROM debian:bookworm-slim as bpftool-build
+FROM ubuntu:22.04 as bpftool-build
 
 ARG SOURCE_REPO=https://github.com/libbpf/bpftool.git
 ARG SOURCE_REF=main

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: image
 ###############################################################################
 # Input parameters.
 ###############################################################################
-DOCKER_PLATFORMS ?= linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x
 VERSION ?= v7.5.0
 IMAGE_ORG ?= calico
 IMAGE ?= $(IMAGE_ORG)/bpftool:$(VERSION)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make image-single-platform
 
 To build for specific platforms, use the `DOCKER_PLATFORMS` variable:
 ```
-make image DOCKER_PLATFORMS=linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
+make image DOCKER_PLATFORMS=linux/amd64,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x
 ```
 
 To build/push the image:


### PR DESCRIPTION
- Dockerfile: Switch from debian to ubuntu: 
  Currently `debian:bookworm-slim` does not support `riscv64`, while
`debian:trixie-slim` fails to build `libbpf`. Switching to
`ubuntu:22.04` which is sufficient to build even for `riscv64.

- riscv64: Introduce build for RISC-V

Signed-off-by: Bingxin Li <bl497@cam.ac.uk>

Relates: projectcalico/calico#9852